### PR TITLE
improve to_xxx_point functions

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -11,6 +11,16 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: read
+  checks: read
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [1.0.1] - 2025-07-11
+## [1.0.2] - 2025-07-11
+
+### Fixed
+- Reworked `to_xxx_point` functions to really only rely on `to_raw_lonlat` instead of also on `valuetype` in some cases.
+
+## [1.0.1] - 2025-07-12
 ### Added
 Added a method for `Meshes.paramdim` for `FastInGeometry` objects. This is mostly for supporting calls to `GeoTable` with a domain made of `FastInGeometry`s
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeoBasics"
 uuid = "8fb48e0b-3c9c-4361-9123-9e8e6ea58083"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
 
 [deps]

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -123,11 +123,9 @@ end
 
 for name in (:to_cartesian_point, :to_latlon_point)
     @eval $name(T::Type{<:AbstractFloat}) = Base.Fix1($name, T)
-    @eval $name(x) = $name(common_valuetype(AbstractFloat, Float32, x), x)
+    @eval $name(x) = $name(to_raw_lonlat(x))
     # Methods for tuple which extract the valuetype from the input
-    VALID_TUP = Tuple{Number, Number}
-    VALID_INP = Union{VALID_TUP, GeoPlottingHelpers._LONLAT_NT{VALID_TUP}}
-    @eval $name(tp::$VALID_INP) = $name(common_valuetype(AbstractFloat, Float32, tp...), tp)
+    @eval $name(tp::Tuple{Real, Real}) = $name(common_valuetype(AbstractFloat, Float32, tp...), tp)
 end
 
 """

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -66,7 +66,6 @@ end
         lon::Float64
     end
     GeoPlottingHelpers.to_raw_lonlat(ll::LL) = (ll.lon, ll.lat)
-    BasicTypes.valuetype(::LL) = Float64
 
     @test LL(20, 10) |> to_latlon_point(Float32) === Point(LatLon(20f0, 10f0))
     @test LL(20, 10) |> to_cartesian_point(Float32) === Point(Cartesian2D{WGS84Latest}(10f0, 20f0))


### PR DESCRIPTION
This PR does a small change to only rely on types implementing `to_raw_lonlat` as per docstring rather than sometime also requiring `valuetype`