### PR TITLE
Implement function to resample borders of GeoBorders polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.1.0] - 2025-08-19
+### Added
+- Added the `distance_resample` function (and its mutating version `distance_resample!`) for resampling the polygons in a `GeoBorders` instance so that the segments of each ring of the GeoBorder's `polyareas` are not longer than a given distance `target_dist`.
+  - Useful for _oversampling_ a GeoBorders to increase the point density along its borders.
+
 ## [1.0.2] - 2025-07-11
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeoBasics"
 uuid = "8fb48e0b-3c9c-4361-9123-9e8e6ea58083"
-version = "1.0.2"
+version = "1.1.0"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
 
 [deps]

--- a/src/GeoBasics.jl
+++ b/src/GeoBasics.jl
@@ -33,4 +33,7 @@ include("point_inclusion.jl")
 
 include("show.jl")
 
+include("distance_resampling.jl")
+export distance_resample, distance_resample!
+
 end # module GeoBasics

--- a/src/deps_interface.jl
+++ b/src/deps_interface.jl
@@ -2,7 +2,7 @@ GeoPlottingHelpers.geom_iterable(geom::FastInGeometry) = polyareas(LatLon, geom)
 
 ### We explicitly avoid implementing the Meshes interface for FastInGeometry objects here to encourage users to explicitly decide whether to use the LatLon or Cartesian CRS both available in the underlying geometry.
 
-Meshes.paramdim(geom::FastInGeometry) = 2
+Meshes.paramdim(geom::FastInGeometry) = return 2
 
 
 ### Base methods ###

--- a/src/distance_resampling.jl
+++ b/src/distance_resampling.jl
@@ -1,0 +1,66 @@
+function distance_resample(r::RING_LATLON, target_dist)
+	target_dist = enforce_unit(u"m", target_dist)
+	PT = eltype(vertices(r))
+	resampled = PT[] # This will hold the new points of the ring sampled to achieve approximately the desired distance
+	for s in segments(r)
+		normalized_step = target_dist / length(s)
+		parametric_range = range(0, 1; step = normalized_step)
+		for p in parametric_range
+			push!(resampled, s(p))
+		end
+	end
+	return Ring(resampled)
+end
+
+function distance_resample(poly::POLY_LATLON, target_dist)
+    map(rings(poly)) do r
+        distance_resample(r, target_dist)
+    end |> PolyArea
+end
+
+"""
+    distance_resample!(gb::GeoBorders, target_dist)
+
+Take a `GeoBorders` instance and modifies it in place so that all the underlying polyareas have been resampled so that each of their rings do not have segments longer than `target_dist`.
+
+The target maximum distance between points over the polygon borders can be provided either with or without unit (which must be a `Length` if provided). **Numbers without units are interpreted as meters**.
+
+!!! note
+    This function does not guarantee each of the segments to be exactly `target_dist` long, though most of the resulting segments will be very close to it. It will not distort the original shape so all of th original vertices will still be present in each ring of each resampled polygon.
+
+## Returns 
+Returns the modified `GeoBorders` instance.
+
+See also [`distance_resample`](@ref).
+"""
+function distance_resample!(gb::GeoBorders, target_dist)
+    # We will go through each of the polygons stored in `gb` and resample them to achieve the maximum distance between points over the segments being equivalent to the proided `target_dist` 
+    latlon = polyareas(LatLon, gb)
+    cart = polyareas(Cartesian, gb)
+    for i in eachindex(latlon, cart)
+        new_latlon = distance_resample(latlon[i], target_dist)
+        new_cart = cartesian_geometry(new_latlon)
+        latlon[i] = new_latlon
+        cart[i] = new_cart
+        # We don't modify the boundingboxes as they do not change when just resampling
+    end
+    return gb
+end
+
+"""
+    distance_resample(gb::GeoBorders, target_dist)
+
+Take a `GeoBorders` instance and returns a copy of it where all the underlying polyareas have been resampled so that each of their rings do not have segments longer than `target_dist`.
+
+The target maximum distance between points over the polygon borders can be provided either with or without unit (which must be a `Length` if provided). **Numbers without units are interpreted as meters**.
+
+!!! note
+    This function does not guarantee each of the segments to be exactly `target_dist` long, though most of the resulting segments will be very close to it. It will not distort the original shape so all of th original vertices will still be present in each ring of each resampled polygon.
+
+
+## Returns 
+Returns a new `GeoBorders` instance of the same valuetype as the input one. For a function that modifies an existing `GeoBorders` instance, see [`distance_resample!`](@ref).
+"""
+function distance_resample(gb::GeoBorders, target_dist)
+    return distance_resample!(deepcopy(gb), target_dist)
+end

--- a/src/distance_resampling.jl
+++ b/src/distance_resampling.jl
@@ -1,15 +1,15 @@
 function distance_resample(r::RING_LATLON, target_dist)
-	target_dist = enforce_unit(u"m", target_dist)
-	PT = eltype(vertices(r))
-	resampled = PT[] # This will hold the new points of the ring sampled to achieve approximately the desired distance
-	for s in segments(r)
-		normalized_step = target_dist / length(s)
-		parametric_range = range(0, 1; step = normalized_step)
-		for p in parametric_range
-			push!(resampled, s(p))
-		end
-	end
-	return Ring(resampled)
+    target_dist = enforce_unit(u"m", target_dist)
+    PT = eltype(vertices(r))
+    resampled = PT[] # This will hold the new points of the ring sampled to achieve approximately the desired distance
+    for s in segments(r)
+        normalized_step = target_dist / length(s)
+        parametric_range = range(0, 1; step=normalized_step)
+        for p in parametric_range
+            push!(resampled, s(p))
+        end
+    end
+    return Ring(resampled)
 end
 
 function distance_resample(poly::POLY_LATLON, target_dist)

--- a/src/distance_resampling.jl
+++ b/src/distance_resampling.jl
@@ -4,9 +4,13 @@ function distance_resample(r::RING_LATLON, target_dist)
     resampled = PT[] # This will hold the new points of the ring sampled to achieve approximately the desired distance
     for s in segments(r)
         normalized_step = target_dist / length(s)
-        parametric_range = range(0, 1; step=normalized_step)
-        for p in parametric_range
-            push!(resampled, s(p))
+        if normalized_step < 1
+            parametric_range = range(0, 1; step=normalized_step)
+            for p in parametric_range
+                push!(resampled, s(p))
+            end
+        else
+            push!(resampled, s(0))
         end
     end
     return Ring(resampled)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -5,7 +5,7 @@
     using GeoBasics.GeoPlottingHelpers
     using GeoBasics.BasicTypes: BasicTypes, valuetype, with
     using GeoBasics.CoordRefSystems
-    using GeoBasics.Meshes: 𝔼, Point, Box, PolyArea, Multi
+    using GeoBasics.Meshes: 𝔼, Point, Box, PolyArea, Multi, paramdim
     using GeoBasics.CoordRefSystems: LatLon, Cartesian, WGS84Latest
     using GeoBasics.Unitful: Unitful, °, @u_str
     using TestAllocations
@@ -120,7 +120,7 @@ end
 
     gb = GeoBorders{Float64}(rand(PolyArea, 10; crs = LatLon))
 
-    @test Meshes.paramdim(gb) == 2
+    @test paramdim(gb) == 2
 
     @test GeoPlottingHelpers.geom_iterable(gb) == polyareas(LatLon, gb)
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -120,6 +120,8 @@ end
 
     gb = GeoBorders{Float64}(rand(PolyArea, 10; crs = LatLon))
 
+    @test Meshes.paramdim(gb) == 2
+
     @test GeoPlottingHelpers.geom_iterable(gb) == polyareas(LatLon, gb)
 
     ## Base methods

--- a/test/distance_resampling.jl
+++ b/test/distance_resampling.jl
@@ -26,6 +26,10 @@ end
 
     # We test that the total length has not changed (if not by minor rounding errors)
     @test length(onlyring(poly_gb)) ≈ length(onlyring(resampled)) atol = 1u"m"
+    # We also test that all original points are still present in the resampled polygon
+    @test all(eachvertex(onlyring(poly_gb))) do v
+        v in eachvertex(onlyring(resampled))
+    end
 
     # we first test that the starting points are more than 2km apart
     @test all(>(2u"km"), seglengths(poly_gb))

--- a/test/distance_resampling.jl
+++ b/test/distance_resampling.jl
@@ -39,4 +39,10 @@ end
     # Finally we test that also the cartesian polygon was updated. We do so by converting the cartesian to latlon and then measure again the segment lengths (because length of the segments in cartesian loses the length on the actual earth's surface)
     cartesian_candidate = onlypoly(resampled, Cartesian)
     @test all(<(2.0001u"km"), seglengths(latlon_geometry(cartesian_candidate)))
+
+    # Now we test that if the distance is greater than the actual length of each segment the polygon is not changed
+    target_dist = 2 * maximum(seglengths(poly_gb))
+    not_resampled = distance_resample(poly_gb, target_dist)
+
+    @test onlyring(poly_gb) == onlyring(not_resampled)
 end

--- a/test/distance_resampling.jl
+++ b/test/distance_resampling.jl
@@ -1,0 +1,38 @@
+@testsnippet setup_distance begin
+    using GeoBasics.Meshes
+    using GeoBasics.Unitful
+    using GeoBasics: latlon_geometry
+    # These are useful for interactive testing in the REPL
+    using GeoBasics
+    using Test
+
+    # This is a helper function to simplify creating a polygon
+    function poly_borders(points::AbstractVector; fix_antimeridian_crossing = true)
+        T = Float32
+        poly = map(to_point(Cartesian, T), points) |> PolyArea
+        return GeoBorders{T}(poly; fix_antimeridian_crossing)
+    end
+
+    onlypoly(x, T::Type = LatLon) = only(polyareas(T, x))
+    onlyring(x, T::Type = LatLon) = only(rings(onlypoly(x, T)))
+
+    seglengths(x) = map(length, segments(onlyring(x, LatLon)))
+end
+
+@testitem "distance_resampling" setup=[setup_distance] begin
+    poly_gb = poly_borders([(0, 0), (1, 0), (1, 1), (0, 1)])
+
+    resampled = distance_resample(poly_gb, 2u"km")
+
+    # We test that the total length has not changed (if not by minor rounding errors)
+    @test length(onlyring(poly_gb)) ≈ length(onlyring(resampled)) atol = 1u"m"
+
+    # we first test that the starting points are more than 2km apart
+    @test all(>(2u"km"), seglengths(poly_gb))
+    # We test that the resampling ensures all points are less than 2km apart
+    @test all(<(2.0001u"km"), seglengths(resampled))
+
+    # Finally we test that also the cartesian polygon was updated. We do so by converting the cartesian to latlon and then measure again the segment lengths (because length of the segments in cartesian loses the length on the actual earth's surface)
+    cartesian_candidate = onlypoly(resampled, Cartesian)
+    @test all(<(2.0001u"km"), seglengths(latlon_geometry(cartesian_candidate)))
+end


### PR DESCRIPTION
This PR adds the `distance_resample` function (and its mutating version `distance_resample!`) for resampling the polygons in a `GeoBorders` instance so that the segments of each ring of the GeoBorder's `polyareas` are not longer than a given distance `target_dist`.
  - Useful for _oversampling_ a GeoBorders to increase the point density along its borders.

